### PR TITLE
jenkins: use same uid as on the host

### DIFF
--- a/ubuntu-15.10-jenkins-slave/Dockerfile
+++ b/ubuntu-15.10-jenkins-slave/Dockerfile
@@ -1,4 +1,4 @@
-# This Dockerfile is used to build an image containing basic stuff to be used as a Jenkins slave build node. 
+# This Dockerfile is used to build an image containing basic stuff to be used as a Jenkins slave build node.
 
 FROM ubuntu:15.04
 MAINTAINER Michael Wittig <michael.wittig@fu-berlin.de>
@@ -10,19 +10,20 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update \
  && apt-get -y upgrade \
 
-# Install a basic SSH server 
+# Install a basic SSH server
  && apt-get install -y openssh-server \
  && sed -i 's|session    required     pam_loginuid.so|session    optional     pam_loginuid.so|g' /etc/pam.d/sshd \
  && mkdir -p /var/run/sshd \
 
-# Install JDK 7 (latest edition) 
+# Install JDK 7 (latest edition)
 # && apt-get install -y --force-yes tzdata=2015c-1
  && apt-get install -y openjdk-7-jdk \
 
-# Add user jenkins to the image 
- && useradd -m jenkins \
+# Add user jenkins to the image, use the some arbitrary high uid and gid to
+# circumvent any clashes with host users
+ && useradd --uid 4000 --gid 4000 -m jenkins \
 
-# Set random passwords for the root and jenkins users. 
+# Set random passwords for the root and jenkins users.
  && echo "root:$(< /dev/urandom tr -dc A-Za-z0-9 | head -c 32)" | chpasswd \
  && echo "jenkins:$(< /dev/urandom tr -dc A-Za-z0-9 | head -c 32)" | chpasswd \
 
@@ -31,6 +32,6 @@ RUN apt-get -y update \
 
  && echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/4M6G+wnzZFaxio8EVRhKXz/RMa1e0hh2eZeE5Da4S9pQnR7zcZNa90bpqHA9GOUfrYMoLOYXoQp5iKq/WzTzhQmVe6mxxuJMUWCQC1Ne2BMB3OkYjGeOeM4bRzFbM1SVxYAumoncdRB/77FN6D1EYgBWTr0ySRQOy3AbH5wMSb2ZKnhrd4W5JMqAxqyrSCoFUlXzD9gMeHzFhOoUItMh62U6CYPAErRDLPaFqjVOR9thzpfYl5xQ3xrS0ldmY8wL3u7mtMHG5wPt2xV4mfyHUqGlONpBKINPH4qKtJ3qsxdyaR0tvxCy8cbEEJLnfJFQcOg88E9X6M2NWVdNks/v jenkins@flip" >> /home/jenkins/.ssh/authorized_keys
 
-# Start sshd and export Standard SSH port 
-EXPOSE 22 
+# Start sshd and export Standard SSH port
+EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]


### PR DESCRIPTION
Currently the jenkins user gets uid 1000. Which collides with my user id on the host system. 
The uid and gid is changed to match the host jenkins user.
